### PR TITLE
readme update to verify commits since previous tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ In your `~/.gitconfig`:
 To tag,
 
 ```bash
+# First make sure all changes since the last tag are legit!
+PREVIOUS_TAG=`git describe --abbrev=0`
+# check the signature of the previous tag
+git tag -v $PREVIOUS_TAG
+# check the commit logs between the previous tag and HEAD
+git log `git describe --abbrev=0`..HEAD
+# check the diff between the previous tag and HEAD
+git diff `git describe --abbrev=0`
+# if that all looks good, tag
 DATE=`date +%Y%M%d%H%m%S`
 git tag -s -m "production-$DATE" production-$DATE [REVISION]
 ```


### PR DESCRIPTION
It might be beneficial to keep the signed commits anyway, for extra security and ease of verification.  But in the meantime, this is how to verify the changes since the previous tag.