### PR TITLE
README: Tag with UTC instead of timezone-dependent time

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ git log "$PREVIOUS_TAG"..HEAD
 # check the diff between the previous tag and HEAD
 git diff "$PREVIOUS_TAG"
 # if that all looks good, tag
-DATE=`date +%Y%m%d%H%M%S`
+DATE=`date --utc +%Y%m%d%H%M%S`
 git tag -s -m "production-$DATE" production-$DATE
 git push --tags
 # you also need to `git push --tags` to the upstream repo


### PR DESCRIPTION
Without UTC, we may end up in a case where a later tag has an earlier timestamp. This is now a huge issue, considering the use of `git describe --abbrev=0`, but this looks nicer this way 😃 